### PR TITLE
Use caddy adapt to manage proxies

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template_string, request, redirect, url_for, flash
 import subprocess
+import json
 
 import os
 
@@ -32,41 +33,97 @@ def raw_edit():
     status = caddy_status()
     return render_template_string(RAW_TEMPLATE, content=content, status=status)
 
-def parse_entries(text: str):
+def load_caddy_json():
+    """Return the Caddyfile adapted to JSON using Caddy itself."""
+    try:
+        result = subprocess.run(
+            ['caddy', 'adapt', '--pretty', '--config', CADDYFILE_PATH],
+            capture_output=True, text=True, check=True
+        )
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        flash(f'Error adapting Caddyfile: {e.stderr}', 'error')
+        return {}
+
+
+def find_proxy_in_route(route):
+    for h in route.get('handle', []):
+        p = find_proxy_in_handle(h)
+        if p:
+            return p
+    return None
+
+
+def find_proxy_in_handle(h):
+    if h.get('handler') == 'reverse_proxy':
+        ups = h.get('upstreams', [])
+        if ups:
+            return ups[0].get('dial')
+    if h.get('handler') == 'subroute':
+        for r in h.get('routes', []):
+            p = find_proxy_in_route(r)
+            if p:
+                return p
+    return None
+
+
+def route_has_proxy(route):
+    return find_proxy_in_route(route) is not None
+
+
+def parse_entries(config):
     entries = []
-    lines = iter(text.splitlines())
-    for line in lines:
-        stripped = line.strip()
-        if not stripped or stripped.startswith('#'):
-            continue
-        if stripped.endswith('{'):
-            domain = stripped[:-1].strip()
-            proxy = ''
-            for inner in lines:
-                s = inner.strip()
-                if s.startswith('reverse_proxy'):
-                    proxy = s[len('reverse_proxy'):].strip()
-                if s == '}':
-                    break
-            if domain and proxy:
-                entries.append({'domain': domain, 'proxy': proxy})
+    servers = config.get('apps', {}).get('http', {}).get('servers', {})
+    for server in servers.values():
+        for route in server.get('routes', []):
+            hosts = []
+            for m in route.get('match', []):
+                if 'host' in m:
+                    hosts.extend(m['host'])
+            if not hosts:
+                continue
+            proxy = find_proxy_in_route(route)
+            if proxy:
+                entries.append({'domain': ','.join(hosts), 'proxy': proxy})
     return entries
 
-def serialize_entries(entries):
-    blocks = []
-    for e in entries:
-        blocks.append(f"{e['domain']} {{\n    reverse_proxy {e['proxy']}\n}}")
-    return "\n\n".join(blocks) + "\n"
+def json_to_caddyfile(config):
+    def collect_directives(route, collected):
+        for h in route.get('handle', []):
+            if h.get('handler') == 'reverse_proxy':
+                ups = h.get('upstreams', [])
+                if ups:
+                    collected.append(f"    reverse_proxy {ups[0]['dial']}")
+            elif h.get('handler') == 'file_server':
+                collected.append("    file_server")
+            elif h.get('handler') == 'vars' and 'root' in h:
+                collected.append(f"    root * {h['root']}")
+            elif h.get('handler') == 'subroute':
+                for r in h.get('routes', []):
+                    collect_directives(r, collected)
+
+    lines = []
+    servers = config.get('apps', {}).get('http', {}).get('servers', {})
+    for server in servers.values():
+        for route in server.get('routes', []):
+            hosts = []
+            for m in route.get('match', []):
+                if 'host' in m:
+                    hosts.extend(m['host'])
+            if not hosts:
+                continue
+            lines.append(f"{' '.join(hosts)} {{")
+            directives = []
+            collect_directives(route, directives)
+            lines.extend(directives)
+            lines.append("}")
+            lines.append("")
+    return "\n".join(lines)
 
 @app.route('/manage', methods=['GET'])
 def manage():
-    try:
-        with open(CADDYFILE_PATH, 'r') as f:
-            content = f.read()
-    except FileNotFoundError:
-        content = ''
-        flash(f"Caddyfile not found at {CADDYFILE_PATH}", 'error')
-    entries = parse_entries(content)
+    config = load_caddy_json()
+    entries = parse_entries(config)
     status = caddy_status()
     return render_template_string(MANAGE_TEMPLATE, entries=entries, status=status)
 
@@ -79,10 +136,44 @@ def save_entries():
         for d, p in zip(domains, proxies)
         if d.strip() and p.strip()
     ]
-    content = serialize_entries(entries)
+
+    config = load_caddy_json()
+    servers = config.get('apps', {}).get('http', {}).get('servers', {})
+    if not servers:
+        servers['srv0'] = {'listen': [':80'], 'routes': []}
+    for server in servers.values():
+        other_routes = [
+            r for r in server.get('routes', [])
+            if not route_has_proxy(r)
+        ]
+        server['routes'] = other_routes
+        for e in entries:
+            route = {
+                'match': [{'host': [h.strip() for h in e['domain'].split(',')]}],
+                'handle': [{
+                    'handler': 'reverse_proxy',
+                    'upstreams': [{'dial': e['proxy']}]
+                }]
+            }
+            server['routes'].append(route)
+
+    new_caddyfile = json_to_caddyfile(config)
+    try:
+        fmt = subprocess.run(
+            ['caddy', 'fmt'],
+            input=new_caddyfile,
+            text=True,
+            capture_output=True,
+            check=True
+        )
+        formatted = fmt.stdout
+    except subprocess.CalledProcessError as e:
+        flash(f'Formatting failed: {e.stderr}', 'error')
+        formatted = new_caddyfile
+
     try:
         with open(CADDYFILE_PATH, 'w') as f:
-            f.write(content)
+            f.write(formatted)
         flash('Entries saved successfully.', 'success')
     except IOError as e:
         flash(f'Error saving file: {e}', 'error')


### PR DESCRIPTION
## Summary
- rely on `caddy adapt` to read the Caddyfile
- parse adapted JSON to list reverse proxy blocks
- rebuild updated JSON and format back to Caddyfile on save
- handle nested `subroute` blocks when extracting proxies

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68421efb93cc8326ac9c924da1aef0c3